### PR TITLE
[feat] 영화 예매 취소하기 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,11 +29,18 @@ dependencies {
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 
+	// JPA
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation group: 'org.postgresql', name: 'postgresql', version: '42.7.3'
+
 	// Actuator
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
 	// Test
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
+	// swagger
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
 }
 
 tasks.named('test') {

--- a/src/main/java/org/sopt/cgv/config/SwaggerConfig.java
+++ b/src/main/java/org/sopt/cgv/config/SwaggerConfig.java
@@ -1,0 +1,23 @@
+package org.sopt.cgv.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        Info info = new Info()
+                .title("Seminar Swagger")
+                .description("NOW SOPT 34th Server Part CDSP cgv Swagger API")
+                .version("v1");
+
+        return new OpenAPI()
+                .components(new Components())
+                .info(info);
+    }
+}

--- a/src/main/java/org/sopt/cgv/controller/MovieController.java
+++ b/src/main/java/org/sopt/cgv/controller/MovieController.java
@@ -1,13 +1,12 @@
 package org.sopt.cgv.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.sopt.cgv.service.HeartsService;
 import org.sopt.cgv.service.MovieService;
 import org.sopt.cgv.service.dto.MovieDetailRequestDto;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -15,11 +14,21 @@ import org.springframework.web.bind.annotation.RestController;
 public class MovieController implements MovieControllerSwagger {
 
     private final MovieService movieService;
+    private final HeartsService likeService;
 
     @GetMapping("/{movieId}/details")
     public ResponseEntity<MovieDetailRequestDto> getMovieDetail(
             @PathVariable Long movieId
     ) {
         return ResponseEntity.ok(movieService.findMovieDetailById(movieId));
+    }
+
+    @PostMapping("/{movieId}/hearts")
+    public ResponseEntity likeMovie(
+            @PathVariable Long movieId
+    ) {
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .header("Location", likeService.addHearts(movieId))
+                .build();
     }
 }

--- a/src/main/java/org/sopt/cgv/controller/MovieController.java
+++ b/src/main/java/org/sopt/cgv/controller/MovieController.java
@@ -53,4 +53,12 @@ public class MovieController implements MovieControllerSwagger {
                 .build();
     }
 
+    @DeleteMapping("/{movieId}/tickets")
+    public ResponseEntity cancelTicket(
+            @PathVariable Long movieId
+    ) {
+        TicketService.cancelTicket(movieId);
+        return ResponseEntity.noContent().build();
+    }
+
 }

--- a/src/main/java/org/sopt/cgv/controller/MovieController.java
+++ b/src/main/java/org/sopt/cgv/controller/MovieController.java
@@ -14,7 +14,7 @@ import org.springframework.web.bind.annotation.*;
 public class MovieController implements MovieControllerSwagger {
 
     private final MovieService movieService;
-    private final HeartsService likeService;
+    private final HeartsService heartsService;
 
     @GetMapping("/{movieId}/details")
     public ResponseEntity<MovieDetailRequestDto> getMovieDetail(
@@ -28,7 +28,15 @@ public class MovieController implements MovieControllerSwagger {
             @PathVariable Long movieId
     ) {
         return ResponseEntity.status(HttpStatus.CREATED)
-                .header("Location", likeService.addHearts(movieId))
+                .header("Location", heartsService.addHearts(movieId))
                 .build();
+    }
+
+    @DeleteMapping("/{movieId}/hearts")
+    public ResponseEntity unlikeMovie(
+            @PathVariable Long movieId
+    ) {
+        heartsService.deleteHearts(movieId);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/org/sopt/cgv/controller/MovieController.java
+++ b/src/main/java/org/sopt/cgv/controller/MovieController.java
@@ -3,7 +3,9 @@ package org.sopt.cgv.controller;
 import lombok.RequiredArgsConstructor;
 import org.sopt.cgv.service.HeartsService;
 import org.sopt.cgv.service.MovieService;
+import org.sopt.cgv.service.TicketService;
 import org.sopt.cgv.service.dto.MovieDetailRequestDto;
+import org.sopt.cgv.service.dto.TicketCreateRequestDto;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -15,6 +17,7 @@ public class MovieController implements MovieControllerSwagger {
 
     private final MovieService movieService;
     private final HeartsService heartsService;
+    private final TicketService TicketService;
 
     @GetMapping("/{movieId}/details")
     public ResponseEntity<MovieDetailRequestDto> getMovieDetail(
@@ -39,4 +42,15 @@ public class MovieController implements MovieControllerSwagger {
         heartsService.deleteHearts(movieId);
         return ResponseEntity.noContent().build();
     }
+
+    @PostMapping("/{movieId}/tickets")
+    public ResponseEntity buyTicket(
+            @PathVariable Long movieId,
+            @RequestBody TicketCreateRequestDto ticketCreateRequestDto
+    ) {
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .header("Location", TicketService.buyTicket(movieId, ticketCreateRequestDto))
+                .build();
+    }
+
 }

--- a/src/main/java/org/sopt/cgv/controller/MovieController.java
+++ b/src/main/java/org/sopt/cgv/controller/MovieController.java
@@ -1,0 +1,25 @@
+package org.sopt.cgv.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.cgv.service.MovieService;
+import org.sopt.cgv.service.dto.MovieDetailRequestDto;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/movies")
+public class MovieController implements MovieControllerSwagger {
+
+    private final MovieService movieService;
+
+    @GetMapping("/{movieId}/details")
+    public ResponseEntity<MovieDetailRequestDto> getMovieDetail(
+            @PathVariable Long movieId
+    ) {
+        return ResponseEntity.ok(movieService.findMovieDetailById(movieId));
+    }
+}

--- a/src/main/java/org/sopt/cgv/controller/MovieControllerSwagger.java
+++ b/src/main/java/org/sopt/cgv/controller/MovieControllerSwagger.java
@@ -44,4 +44,7 @@ public interface MovieControllerSwagger {
             })
     ResponseEntity buyTicket(@PathVariable Long movieId, @RequestBody TicketCreateRequestDto ticketCreateRequestDto);
 
+    @Operation(summary = "영화 예매 취소 API")
+    ResponseEntity cancelTicket(@PathVariable Long movieId);
+
 }

--- a/src/main/java/org/sopt/cgv/controller/MovieControllerSwagger.java
+++ b/src/main/java/org/sopt/cgv/controller/MovieControllerSwagger.java
@@ -31,4 +31,7 @@ public interface MovieControllerSwagger {
     })
     ResponseEntity likeMovie(@PathVariable Long movieId);
 
+    @Operation(summary = "영화 좋아요 삭제 API")
+    ResponseEntity unlikeMovie(@PathVariable Long movieId);
+
 }

--- a/src/main/java/org/sopt/cgv/controller/MovieControllerSwagger.java
+++ b/src/main/java/org/sopt/cgv/controller/MovieControllerSwagger.java
@@ -7,8 +7,10 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.sopt.cgv.service.dto.MovieDetailRequestDto;
+import org.sopt.cgv.service.dto.TicketCreateRequestDto;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 
 @Tag(name = "영화 API", description = "영화 관련 API")
 public interface MovieControllerSwagger {
@@ -33,5 +35,13 @@ public interface MovieControllerSwagger {
 
     @Operation(summary = "영화 좋아요 삭제 API")
     ResponseEntity unlikeMovie(@PathVariable Long movieId);
+
+    @Operation(summary = "영화 예매 API")
+    @ApiResponses(
+            value = {
+                    @ApiResponse(responseCode = "201", description = "Ticket added successfully"),
+                    @ApiResponse(responseCode = "404", description = "Theater not found")
+            })
+    ResponseEntity buyTicket(@PathVariable Long movieId, @RequestBody TicketCreateRequestDto ticketCreateRequestDto);
 
 }

--- a/src/main/java/org/sopt/cgv/controller/MovieControllerSwagger.java
+++ b/src/main/java/org/sopt/cgv/controller/MovieControllerSwagger.java
@@ -1,0 +1,25 @@
+package org.sopt.cgv.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.sopt.cgv.service.dto.MovieDetailRequestDto;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@Tag(name = "영화 API", description = "영화 관련 API")
+public interface MovieControllerSwagger {
+
+    @Operation(summary = "영화 세부 정보 조회 API")
+    @ApiResponses(
+            value = {
+                    @ApiResponse(responseCode = "200",
+                            content = @Content(mediaType = "application/json",
+                                    schema = @Schema(implementation = MovieDetailRequestDto.class))),
+            }
+    )
+    ResponseEntity<MovieDetailRequestDto> getMovieDetail(@PathVariable Long movieId);
+}

--- a/src/main/java/org/sopt/cgv/controller/MovieControllerSwagger.java
+++ b/src/main/java/org/sopt/cgv/controller/MovieControllerSwagger.java
@@ -22,4 +22,13 @@ public interface MovieControllerSwagger {
             }
     )
     ResponseEntity<MovieDetailRequestDto> getMovieDetail(@PathVariable Long movieId);
+
+    @Operation(summary = "영화 좋아요 클릭 API")
+    @ApiResponses(
+            value = {
+                    @ApiResponse(responseCode = "201", description = "Like added successfully"),
+                    @ApiResponse(responseCode = "404", description = "Movie not found")
+    })
+    ResponseEntity likeMovie(@PathVariable Long movieId);
+
 }

--- a/src/main/java/org/sopt/cgv/domain/Hearts.java
+++ b/src/main/java/org/sopt/cgv/domain/Hearts.java
@@ -8,7 +8,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor
-public class hearts {
+public class Hearts {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -18,12 +18,12 @@ public class hearts {
     private Movie movie;
 
     @Builder
-    private hearts(Movie movie) {
+    private Hearts(Movie movie) {
         this.movie = movie;
     }
 
-    public static hearts create(Movie movie) {
-        return hearts.builder()
+    public static Hearts create(Movie movie) {
+        return Hearts.builder()
                 .movie(movie)
                 .build();
     }

--- a/src/main/java/org/sopt/cgv/domain/Movie.java
+++ b/src/main/java/org/sopt/cgv/domain/Movie.java
@@ -1,0 +1,39 @@
+package org.sopt.cgv.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class Movie {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String title;
+
+    private float reservationRate;
+
+    private float eggRate;
+
+    private float goldenEggRate;
+
+    private LocalDate releaseDate;
+
+    private String filmRatings;
+
+    private String imageUrl;
+
+    private String genres;
+
+    private String theaterType;
+
+    @Column(columnDefinition = "TEXT")
+    private String script;
+
+    private int rank;
+}

--- a/src/main/java/org/sopt/cgv/domain/Theater.java
+++ b/src/main/java/org/sopt/cgv/domain/Theater.java
@@ -1,0 +1,31 @@
+package org.sopt.cgv.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalTime;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class Theater {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String theaterName;
+
+    private int maxSeats;
+
+    private String theaterType;
+
+    private LocalTime startAt;
+
+    private LocalTime endAt;
+
+    private int remainingSeats;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Movie movie;
+}

--- a/src/main/java/org/sopt/cgv/domain/Ticket.java
+++ b/src/main/java/org/sopt/cgv/domain/Ticket.java
@@ -1,0 +1,30 @@
+package org.sopt.cgv.domain;
+
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class Ticket {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Theater theater;
+
+    @Builder
+    private Ticket(Theater theater) {
+        this.theater = theater;
+    }
+
+    public static Ticket create(Theater theater) {
+        return Ticket.builder()
+                .theater(theater)
+                .build();
+    }
+}

--- a/src/main/java/org/sopt/cgv/domain/Ticket.java
+++ b/src/main/java/org/sopt/cgv/domain/Ticket.java
@@ -17,9 +17,12 @@ public class Ticket {
     @ManyToOne(fetch = FetchType.LAZY)
     private Theater theater;
 
+    private Long movieId;
+
     @Builder
     private Ticket(Theater theater) {
         this.theater = theater;
+        this.movieId = theater.getMovie().getId();
     }
 
     public static Ticket create(Theater theater) {

--- a/src/main/java/org/sopt/cgv/domain/hearts.java
+++ b/src/main/java/org/sopt/cgv/domain/hearts.java
@@ -1,0 +1,30 @@
+package org.sopt.cgv.domain;
+
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class hearts {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne
+    private Movie movie;
+
+    @Builder
+    private hearts(Movie movie) {
+        this.movie = movie;
+    }
+
+    public static hearts create(Movie movie) {
+        return hearts.builder()
+                .movie(movie)
+                .build();
+    }
+}

--- a/src/main/java/org/sopt/cgv/repository/HeartsRepository.java
+++ b/src/main/java/org/sopt/cgv/repository/HeartsRepository.java
@@ -1,0 +1,7 @@
+package org.sopt.cgv.repository;
+
+import org.sopt.cgv.domain.hearts;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface HeartsRepository extends JpaRepository<hearts, Long> {
+}

--- a/src/main/java/org/sopt/cgv/repository/HeartsRepository.java
+++ b/src/main/java/org/sopt/cgv/repository/HeartsRepository.java
@@ -1,7 +1,11 @@
 package org.sopt.cgv.repository;
 
-import org.sopt.cgv.domain.hearts;
+import org.sopt.cgv.domain.Hearts;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface HeartsRepository extends JpaRepository<hearts, Long> {
+import java.util.Optional;
+
+public interface HeartsRepository extends JpaRepository<Hearts, Long> {
+
+    Optional<Hearts> findByMovieId(Long movieId);
 }

--- a/src/main/java/org/sopt/cgv/repository/MovieRepository.java
+++ b/src/main/java/org/sopt/cgv/repository/MovieRepository.java
@@ -1,0 +1,7 @@
+package org.sopt.cgv.repository;
+
+import org.sopt.cgv.domain.Movie;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MovieRepository extends JpaRepository<Movie, Long> {
+}

--- a/src/main/java/org/sopt/cgv/repository/TheaterRepository.java
+++ b/src/main/java/org/sopt/cgv/repository/TheaterRepository.java
@@ -1,0 +1,9 @@
+package org.sopt.cgv.repository;
+
+import org.sopt.cgv.domain.Theater;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface TheaterRepository extends JpaRepository<Theater, Long> {
+}

--- a/src/main/java/org/sopt/cgv/repository/TicketRepository.java
+++ b/src/main/java/org/sopt/cgv/repository/TicketRepository.java
@@ -1,0 +1,7 @@
+package org.sopt.cgv.repository;
+
+import org.sopt.cgv.domain.Ticket;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TicketRepository extends JpaRepository<Ticket, Long> {
+}

--- a/src/main/java/org/sopt/cgv/repository/TicketRepository.java
+++ b/src/main/java/org/sopt/cgv/repository/TicketRepository.java
@@ -3,5 +3,10 @@ package org.sopt.cgv.repository;
 import org.sopt.cgv.domain.Ticket;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+import java.util.Optional;
+
 public interface TicketRepository extends JpaRepository<Ticket, Long> {
+
+    List<Ticket> findByMovieId(Long movieId);
 }

--- a/src/main/java/org/sopt/cgv/service/HeartsService.java
+++ b/src/main/java/org/sopt/cgv/service/HeartsService.java
@@ -1,7 +1,7 @@
 package org.sopt.cgv.service;
 
 import lombok.RequiredArgsConstructor;
-import org.sopt.cgv.domain.hearts;
+import org.sopt.cgv.domain.Hearts;
 import org.sopt.cgv.domain.Movie;
 import org.sopt.cgv.repository.HeartsRepository;
 import org.sopt.cgv.repository.MovieRepository;
@@ -12,7 +12,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class HeartsService {
 
-    private final HeartsRepository likeRepository;
+    private final HeartsRepository heartsRepository;
     private final MovieRepository movieRepository;
 
     @Transactional
@@ -20,8 +20,16 @@ public class HeartsService {
         Movie movie = movieRepository.findById(movieId)
                 .orElseThrow(() -> new IllegalArgumentException("해당 영화를 찾을 수 없습니다.")
                 );
-        hearts like = hearts.create(movie);
-        likeRepository.save(like);
-        return like.getId().toString();
+        Hearts hearts = Hearts.create(movie);
+        heartsRepository.save(hearts);
+        return hearts.getId().toString();
+    }
+
+    @Transactional
+    public void deleteHearts(Long movieId) {
+        Hearts hearts = heartsRepository.findByMovieId(movieId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 영화의 좋아요를 찾을 수 없습니다.")
+                );
+        heartsRepository.delete(hearts);
     }
 }

--- a/src/main/java/org/sopt/cgv/service/HeartsService.java
+++ b/src/main/java/org/sopt/cgv/service/HeartsService.java
@@ -1,0 +1,27 @@
+package org.sopt.cgv.service;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.cgv.domain.hearts;
+import org.sopt.cgv.domain.Movie;
+import org.sopt.cgv.repository.HeartsRepository;
+import org.sopt.cgv.repository.MovieRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class HeartsService {
+
+    private final HeartsRepository likeRepository;
+    private final MovieRepository movieRepository;
+
+    @Transactional
+    public String addHearts(Long movieId) {
+        Movie movie = movieRepository.findById(movieId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 영화를 찾을 수 없습니다.")
+                );
+        hearts like = hearts.create(movie);
+        likeRepository.save(like);
+        return like.getId().toString();
+    }
+}

--- a/src/main/java/org/sopt/cgv/service/MovieService.java
+++ b/src/main/java/org/sopt/cgv/service/MovieService.java
@@ -1,0 +1,24 @@
+package org.sopt.cgv.service;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.cgv.domain.Movie;
+import org.sopt.cgv.repository.MovieRepository;
+import org.sopt.cgv.service.dto.MovieDetailRequestDto;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MovieService {
+
+    private final MovieRepository MovieRepository;
+
+    public Movie findById(Long movieId) {
+        return MovieRepository.findById(movieId).orElseThrow(
+                () -> new IllegalArgumentException("해당 영화를 찾을 수 없습니다.")
+        );
+    }
+
+    public MovieDetailRequestDto findMovieDetailById(Long movieId) {
+        return MovieDetailRequestDto.of(findById(movieId));
+    }
+}

--- a/src/main/java/org/sopt/cgv/service/MovieService.java
+++ b/src/main/java/org/sopt/cgv/service/MovieService.java
@@ -2,6 +2,7 @@ package org.sopt.cgv.service;
 
 import lombok.RequiredArgsConstructor;
 import org.sopt.cgv.domain.Movie;
+import org.sopt.cgv.repository.HeartsRepository;
 import org.sopt.cgv.repository.MovieRepository;
 import org.sopt.cgv.service.dto.MovieDetailRequestDto;
 import org.springframework.stereotype.Service;
@@ -11,6 +12,7 @@ import org.springframework.stereotype.Service;
 public class MovieService {
 
     private final MovieRepository MovieRepository;
+    private final HeartsRepository heartsRepository;
 
     public Movie findById(Long movieId) {
         return MovieRepository.findById(movieId)
@@ -19,6 +21,8 @@ public class MovieService {
     }
 
     public MovieDetailRequestDto findMovieDetailById(Long movieId) {
-        return MovieDetailRequestDto.of(findById(movieId));
+        Movie movie = findById(movieId);
+        boolean isLiked = heartsRepository.findByMovieId(movieId).isPresent();
+        return MovieDetailRequestDto.of(movie, isLiked);
     }
 }

--- a/src/main/java/org/sopt/cgv/service/MovieService.java
+++ b/src/main/java/org/sopt/cgv/service/MovieService.java
@@ -13,8 +13,8 @@ public class MovieService {
     private final MovieRepository MovieRepository;
 
     public Movie findById(Long movieId) {
-        return MovieRepository.findById(movieId).orElseThrow(
-                () -> new IllegalArgumentException("해당 영화를 찾을 수 없습니다.")
+        return MovieRepository.findById(movieId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 영화를 찾을 수 없습니다.")
         );
     }
 

--- a/src/main/java/org/sopt/cgv/service/TicketService.java
+++ b/src/main/java/org/sopt/cgv/service/TicketService.java
@@ -1,0 +1,28 @@
+package org.sopt.cgv.service;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.cgv.domain.Theater;
+import org.sopt.cgv.domain.Ticket;
+import org.sopt.cgv.repository.TheaterRepository;
+import org.sopt.cgv.repository.TicketRepository;
+import org.sopt.cgv.service.dto.TicketCreateRequestDto;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class TicketService {
+
+    private final TicketRepository ticketRepository;
+    private final TheaterRepository theaterRepository;
+
+    @Transactional
+    public String buyTicket(Long movieId, TicketCreateRequestDto ticketCreateRequestDto) {
+        Theater theater = theaterRepository.findById(ticketCreateRequestDto.theaterId())
+                .orElseThrow(() -> new IllegalArgumentException("해당 영화를 상영하는 상영관을 찾을 수 없습니다.")
+                );
+        Ticket ticket = Ticket.create(theater);
+        ticketRepository.save(ticket);
+        return ticket.getId().toString();
+    }
+}

--- a/src/main/java/org/sopt/cgv/service/TicketService.java
+++ b/src/main/java/org/sopt/cgv/service/TicketService.java
@@ -9,6 +9,9 @@ import org.sopt.cgv.service.dto.TicketCreateRequestDto;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+import java.util.Optional;
+
 @Service
 @RequiredArgsConstructor
 public class TicketService {
@@ -24,5 +27,11 @@ public class TicketService {
         Ticket ticket = Ticket.create(theater);
         ticketRepository.save(ticket);
         return ticket.getId().toString();
+    }
+
+    @Transactional
+    public void cancelTicket(Long movieId) {
+        List<Ticket> tickets = ticketRepository.findByMovieId(movieId);
+        ticketRepository.deleteAll(tickets);
     }
 }

--- a/src/main/java/org/sopt/cgv/service/dto/MovieDetailRequestDto.java
+++ b/src/main/java/org/sopt/cgv/service/dto/MovieDetailRequestDto.java
@@ -1,0 +1,12 @@
+package org.sopt.cgv.service.dto;
+
+import org.sopt.cgv.domain.Movie;
+
+public record MovieDetailRequestDto (
+        String title,
+        String script
+) {
+    public static MovieDetailRequestDto of(Movie movie) {
+        return new MovieDetailRequestDto(movie.getTitle(), movie.getScript());
+    }
+}

--- a/src/main/java/org/sopt/cgv/service/dto/MovieDetailRequestDto.java
+++ b/src/main/java/org/sopt/cgv/service/dto/MovieDetailRequestDto.java
@@ -4,9 +4,10 @@ import org.sopt.cgv.domain.Movie;
 
 public record MovieDetailRequestDto (
         String title,
-        String script
+        String script,
+        boolean isLiked
 ) {
-    public static MovieDetailRequestDto of(Movie movie) {
-        return new MovieDetailRequestDto(movie.getTitle(), movie.getScript());
+    public static MovieDetailRequestDto of(Movie movie, boolean isLiked) {
+        return new MovieDetailRequestDto(movie.getTitle(), movie.getScript(), isLiked);
     }
 }

--- a/src/main/java/org/sopt/cgv/service/dto/TicketCreateRequestDto.java
+++ b/src/main/java/org/sopt/cgv/service/dto/TicketCreateRequestDto.java
@@ -1,0 +1,9 @@
+package org.sopt.cgv.service.dto;
+
+public record TicketCreateRequestDto(
+        Long theaterId
+) {
+    public static TicketCreateRequestDto of(Long theaterId) {
+        return new TicketCreateRequestDto(theaterId);
+    }
+}


### PR DESCRIPTION
## Related Issue 📌
- close #13 
## Description ✔️
영화 예매 취소하기 api 구현
예매 취소하기를 눌렀을 때, 해당 영화의 모든 예매 내역을 삭제하도록 구현함
https://github.com/NOW-SOPT-CDSP-WEB5/CGV-SERVER/blob/50d67831065a06e3780a0cab33f2768982234865/src/main/java/org/sopt/cgv/domain/Ticket.java#L11-L33
Ticket 엔티티를 구현하였는데, 영화 기본키 값을 넣기 위해서 Movie 엔티티와 연관관계를 설정하였더니 이행적 함수 종속(?) 형태가 되는 것 같아서.. 아래 그림처럼 erd가 좀 이상해.. (이거 이렇게 되면 안된다고 배웠던거 같은데..)
<img width="570" alt="image" src="https://github.com/NOW-SOPT-CDSP-WEB5/CGV-SERVER/assets/84284757/df2d81f3-9e94-40c3-a6b0-e5559830bc1b">

그래서 굳이 Movie랑 연관관계를 짓지 않고 기존의 theaters 속성으로 영화의 기본키 값을 불러올 수 있어서 코드를 위처럼 작성했는데 이 방법말고 그냥 Movie 엔티티랑 연관관계를 맺는게 더 나을까??      


<img width="1420" alt="image" src="https://github.com/NOW-SOPT-CDSP-WEB5/CGV-SERVER/assets/84284757/04cfc4b3-53ae-4901-b8c5-a4bf6112e838">
